### PR TITLE
fix: 修复在初次添加插件时因没有添加小组件导致的崩溃

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,6 +148,8 @@ class Plugin:
 
     def auto_scroll(self):
         """自动滚动功能"""
+        if self.test_widget is None:  # 若小组件不存在，则不执行
+            return
         scroll_area = self.test_widget.findChild(QScrollArea)
         if scroll_area:
             vertical_scrollbar = scroll_area.verticalScrollBar()

--- a/main.py
+++ b/main.py
@@ -148,7 +148,7 @@ class Plugin:
 
     def auto_scroll(self):
         """自动滚动功能"""
-        if self.test_widget is None:  # 若小组件不存在，则不执行
+        if self.test_widget is None:  # 如果小组件不存在，则不执行
             return
         scroll_area = self.test_widget.findChild(QScrollArea)
         if scroll_area:


### PR DESCRIPTION
在初次启用本插件时,本插件的auto_scroll功能未判断小组件是否被用户添加,从而因为找不到QScrollArea而崩溃。

#### 错误信息：
```
Traceback (most recent call last):
  File "X:\Users\lintu\Desktop\PythonProject\Class-Widgets\plugins\cw-yiyan-plugin\main.py", line 153, in auto_scroll
    scroll_area = self.test_widget.findChild(QScrollArea)
AttributeError: 'NoneType' object has no attribute 'findChild'
```